### PR TITLE
include static template context processor

### DIFF
--- a/match/settings_shared.py
+++ b/match/settings_shared.py
@@ -63,6 +63,7 @@ TEMPLATE_CONTEXT_PROCESSORS = (
     'django.contrib.auth.context_processors.auth',
     'django.core.context_processors.debug',
     'django.core.context_processors.request',
+    'django.core.context_processors.static',
     'djangowind.context.context_processor',
     'stagingcontext.staging_processor',
 )


### PR DESCRIPTION
I think it's responsible for this:

https://sentry.ccnmtl.columbia.edu/sentry-internal/match/group/824/