### PR TITLE
staticfiles configuration

### DIFF
--- a/match/settings_shared.py
+++ b/match/settings_shared.py
@@ -159,6 +159,11 @@ COMPRESS_ROOT = "media/"
 STATICMEDIA_MOUNTS = (
     ('/sitemedia', 'sitemedia'),
 )
+STATICFILES_FINDERS = (
+    'django.contrib.staticfiles.finders.FileSystemFinder',
+    'django.contrib.staticfiles.finders.AppDirectoriesFinder',
+    'compressor.finders.CompressorFinder',
+)
 
 # WIND settings
 


### PR DESCRIPTION
"ImproperlyConfigured: When using Django Compressor together with staticfiles, please add 'compressor.finders.CompressorFinder' to the STATICFILES_FINDERS setting." -- sentry #834