### PR TITLE
remove dependency on django-annoying

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -59,7 +59,6 @@ djangowind==0.14.3
 sorl==3.1
 django-indexer==0.3.0
 django-paging==0.2.5
-django-annoying==0.8.7
 django-treebeard==3.0
 django-statsd-mozilla==0.3.16
 django-bootstrap-form==3.2


### PR DESCRIPTION
does not appear to be in use