### PR TITLE
remove null from ManyToMany

### DIFF
--- a/match/nutrition/migrations/0002_auto_20160613_1235.py
+++ b/match/nutrition/migrations/0002_auto_20160613_1235.py
@@ -1,0 +1,20 @@
+# flake8: noqa
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('nutrition', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='counselingsessionstate',
+            name='answered',
+            field=models.ManyToManyField(to='nutrition.DiscussionTopic', blank=True),
+        ),
+    ]

--- a/match/nutrition/models.py
+++ b/match/nutrition/models.py
@@ -172,7 +172,7 @@ class CounselingSessionState(models.Model):
 
     user = models.ForeignKey(User, related_name="nutrition_discussion_user")
     session = models.ForeignKey(CounselingSession)
-    answered = models.ManyToManyField(DiscussionTopic, null=True, blank=True)
+    answered = models.ManyToManyField(DiscussionTopic, blank=True)
     elapsed_time = models.IntegerField(default=0)
 
 


### PR DESCRIPTION
eliminates:

```
WARNINGS:
nutrition.CounselingSessionState.answered: (fields.W340) null has no effect on ManyToManyField.
```